### PR TITLE
Update .gitignore & fix SSL Connection Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,62 @@ pyvmomi-community-samples/
 methods.pyc
 *.pyc
 *.swp
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ config.json
 env/
 pyvmomi-community-samples/
 methods.pyc
+
 *.pyc
 *.swp
 # Byte-compiled / optimized / DLL files
@@ -63,3 +64,5 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.idea/

--- a/methods.py
+++ b/methods.py
@@ -50,18 +50,27 @@ def debugger():
 
 
 def server_connection():
-    SI = None
     # Attempt to connect to the VCSA
+    import ssl
     try:
-        SI = connect.SmartConnect(host=host, user=user, pwd=pwd,)
-        print("Made the connection")
-        atexit.register(connect.Disconnect, SI)
-    except IOError:
-        pass
+        SI = connect.SmartConnect(host=host,
+                                    user=user,
+                                    pwd=pwd,
+                                    #sslContext=context
+                                  )
+    except requests.exceptions.SSLError as e:
+        print("Falling back to no verification for SSL")
 
-    if not SI:
-        print ("Unable to connect to host with supplied info.")
+        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        context.verify_mode = ssl.CERT_NONE
+        SI = connect.SmartConnect(host=host,
+                                    user=user,
+                                    pwd=pwd,
+                                    sslContext=context
+                              )
 
+    print("Made the connection")
+    atexit.register(connect.Disconnect, SI)
     return SI
 
 # Helper function to so the actually traversal and printing of the vms.


### PR DESCRIPTION
1. Update the gitignore to use the standard python one from [GitHub](https://github.com/github/gitignore/blob/master/Python.gitignore)
2. Update the connection method to automatically fall back to unverified SSL if needed (common in certain vSphere setups) with Python 2.7.9 and higher and its increased SSL verification.  Fixes #1